### PR TITLE
When creating a new event, insert at the end

### DIFF
--- a/src/obComponents/createEvent.ts
+++ b/src/obComponents/createEvent.ts
@@ -185,6 +185,18 @@ export async function insertAfterHandler(
       };
     }
 
+    // Move past all of the existing items
+    for (let i = pos + 1; i < lines.length; i++) {
+      const nextLine = lines[i];
+      if (nextLine == null) { break; }
+      // Assume items starts with 'bullet points'
+      if (nextLine.startsWith('- ')) {
+        continue;
+      }
+      pos = i - 1;
+      break;
+    }
+
     // Insert after the found position
     return await insertTextAfterPositionInBody(formatted, fileContent, pos, found);
   }, 'Failed to insert after handler');


### PR DESCRIPTION
As described in this issue [here](https://github.com/Quorafind/Obsidian-Big-Calendar/issues/48#issuecomment-2970467209), adding new events by clicking through the calendar ui they would end up with a reverse order: latest added shows up on top. Instead, if we create events by adding them to the end of the list of existing items, the events will show up in order of creation.